### PR TITLE
Use fix-sized 64kb ByteBuffer

### DIFF
--- a/src/main/java/com/microsoft/azure/relay/HybridConnectionListener.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridConnectionListener.java
@@ -628,7 +628,7 @@ public class HybridConnectionListener implements RelayTraceSource, AutoCloseable
 							return webSocket.writeAsync(json, timeout, WriteMode.TEXT)
 								.thenCompose($void -> {
 									if (buffer != null) {
-										return webSocket.writeAsync(buffer.array());
+										return webSocket.writeAsync(buffer);
 									} else {
 										return CompletableFuture.completedFuture(null);
 									}

--- a/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
+++ b/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
@@ -417,7 +417,7 @@ public class HybridConnectionListenerTest {
 				response.getHeaders().put(headerKey, headerVal);
 				modifiedAfterClose.complete(null);
 			} catch (Exception e) {
-				modifiedAfterClose.completeExceptionally(e);
+				modifiedAfterClose.completeExceptionally(e.getCause());
 			}
 		});
 		
@@ -427,7 +427,7 @@ public class HybridConnectionListenerTest {
 
 		assertEquals("Response did not have the expected response code.", statusCode, conn.getResponseCode());
 		assertNull("Response should not have set the header successfully.", conn.getHeaderField(headerKey));
-		Assertions.assertCFThrows(IllegalStateException.class, modifiedAfterClose);
+		Assertions.assertCFThrows(IOException.class, modifiedAfterClose);
 		
 		// Test setting status code after writing to response stream
 		CompletableFuture<Void> modifiedStatusAfterWrite = new CompletableFuture<Void>();


### PR DESCRIPTION
- Use fix-sized 64kb ByteBuffer for writing to HTTP response
- Fix failing unit test by correcting expected exception