### PR TITLE
Fixed bugs that prevented consecutive writes to HTTP response from working properly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>azure-relay</artifactId>
-	<version>0.0.2-PREVIEW</version>
+	<version>0.0.1-PREVIEW</version>
 	<packaging>maven-plugin</packaging>
 	<name>azure-relay</name>
 	<description>Java library for Azure Relay</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>azure-relay</artifactId>
-	<version>0.0.1-PREVIEW</version>
+	<version>0.0.2-PREVIEW</version>
 	<packaging>maven-plugin</packaging>
 	<name>azure-relay</name>
 	<description>Java library for Azure Relay</description>

--- a/src/main/java/com/microsoft/azure/relay/ClientWebSocket.java
+++ b/src/main/java/com/microsoft/azure/relay/ClientWebSocket.java
@@ -7,7 +7,6 @@ import java.util.LinkedList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.io.IOException;
-import java.io.Writer;
 
 import javax.websocket.*;
 
@@ -16,6 +15,7 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.websocket.api.UpgradeException;
 
 class ClientWebSocket extends Endpoint implements RelayTraceSource {
+	private final AsyncLock socketLock;
 	private final AutoShutdownScheduledExecutor executor;
 	private final WebSocketContainer container = ContainerProvider.getWebSocketContainer();
 	private final TrackingContext trackingContext;
@@ -26,7 +26,7 @@ class ClientWebSocket extends Endpoint implements RelayTraceSource {
 	private InputQueue<String> textQueue;
 	private CompletableFuture<Void> closeTask;
 	private String cachedString;
-	
+
 	/**
 	 * Creates a websocket instance
 	 */
@@ -36,6 +36,7 @@ class ClientWebSocket extends Endpoint implements RelayTraceSource {
 		this.fragmentQueue = new InputQueue<MessageFragment>(this.executor);
 		this.closeReason = null;
 		this.trackingContext = trackingContext;
+		this.socketLock = new AsyncLock(HybridConnectionListener.EXECUTOR);
 	}
 	
 	public TrackingContext getTrackingContext() {
@@ -200,7 +201,7 @@ class ClientWebSocket extends Endpoint implements RelayTraceSource {
 	 * @throws TimeoutException Throws when the sending task does not complete within the given timeout.
 	 */
 	public CompletableFuture<Void> writeAsync(Object data, Duration timeout) {
-		return writeAsync(data, timeout, WriteMode.BINARY);
+		return writeAsync(data, timeout, true, WriteMode.BINARY);
 	}
 	
 	/**
@@ -208,52 +209,52 @@ class ClientWebSocket extends Endpoint implements RelayTraceSource {
 	 * 
 	 * @param data Message to be sent.
 	 * @param timeout The timeout to connect to send the data within. May be null to indicate no timeout limit.
+	 * @param isEnd Indicates if the data sent is the end of a message
 	 * @param mode The type of the message to be sent.
 	 * @return A CompletableFuture which completes when websocket finishes sending the bytes.
 	 * @throws TimeoutException Throws when the sending task does not complete within the given timeout.
 	 */
-	CompletableFuture<Void> writeAsync(Object data, Duration timeout, WriteMode mode) {
+	CompletableFuture<Void> writeAsync(Object data, Duration timeout, boolean isEnd, WriteMode mode) {
 		if (this.isOpen()) {
 			if (data == null) {
 				// TODO: Log warns sending nothing because message is null
 				return CompletableFuture.completedFuture(null);
 			}
 			else {
-				return CompletableFutureUtil.timedRunAsync(timeout, () -> {
-					RemoteEndpoint.Basic remote = this.session.getBasicRemote();
-					
-					try {
-						if (mode.equals(WriteMode.TEXT)) {
-							String text = data.toString();
-							RelayLogger.logEvent("writingBytes", this, "text");
-							Writer writer = remote.getSendWriter();
-							writer.write(text);
-							writer.close();
-							RelayLogger.logEvent("doneWritingBytes", this, String.valueOf(text.length()));
-						}
-						else {
-							ByteBuffer bytes = null;
-							
-							RelayLogger.logEvent("writingBytes", this, "binary");
-							if (data instanceof byte[]) {
-								bytes = ByteBuffer.wrap((byte[]) data);
-							} 
-							else if (data instanceof ByteBuffer) {
-								bytes = (ByteBuffer) data;
+				RemoteEndpoint.Basic remote = this.session.getBasicRemote();
+				RelayLogger.logEvent("writingBytes", this, mode.toString());
+				
+				// The websocket API will throw if multiple sends are attempted on the same websocket simultaneously
+				// Therefore a lock is used on the send operation
+				return this.socketLock.acquireThenCompose(timeout, () -> {
+					return CompletableFutureUtil.timedRunAsync(timeout, () -> {
+						try {
+							if (mode.equals(WriteMode.TEXT)) {
+								String text = data.toString();
+								remote.sendText(text, isEnd);
+								RelayLogger.logEvent("doneWritingBytes", this, String.valueOf(text.length()));
 							}
-							else if (data instanceof String){
-								bytes = ByteBuffer.wrap(data.toString().getBytes(StringUtil.UTF8));
+							else {
+								ByteBuffer bytes = null;
+								if (data instanceof byte[]) {
+									bytes = ByteBuffer.wrap((byte[]) data);
+								} 
+								else if (data instanceof ByteBuffer) {
+									bytes = (ByteBuffer) data;
+								}
+								else if (data instanceof String){
+									bytes = ByteBuffer.wrap(data.toString().getBytes(StringUtil.UTF8));
+								}
+								
+								int bytesToSend = bytes.remaining();
+								remote.sendBinary(bytes, isEnd);
+								RelayLogger.logEvent("doneWritingBytes", this, String.valueOf(bytesToSend));
 							}
-							int bytesToSend = bytes.remaining();
-							remote.sendBinary(bytes);
-							RelayLogger.logEvent("doneWritingBytes", this, String.valueOf(bytesToSend));
+						} catch (Exception e) {
+							throw RelayLogger.throwingException(e, this);
 						}
-					}
-					catch (IOException e) {
-						throw RelayLogger.throwingException(e, this);
-					}
-				},
-				this.executor);
+					}, executor);
+				});
 			}
 		}
 		else {
@@ -283,16 +284,19 @@ class ClientWebSocket extends Endpoint implements RelayTraceSource {
 		if (this.session == null || !this.session.isOpen()) {
 			return this.closeTask;
 		}
-		try {
-			if (reason != null) {
-				this.session.close(reason);
-			} else {
-				this.session.close();
+
+		this.socketLock.acquireThenApply(null, () -> {
+			try {
+				if (reason != null) {
+					this.session.close(reason);
+				} else {
+					this.session.close();
+				}
+			} catch (Throwable e) {
+				this.closeTask.completeExceptionally(e);
 			}
-		} 
-		catch (Throwable e) {
-			this.closeTask.completeExceptionally(e);
-		}
+			return null;
+		});
 		return this.closeTask;
 	}
 	

--- a/src/main/java/com/microsoft/azure/relay/HybridConnectionListener.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridConnectionListener.java
@@ -625,7 +625,7 @@ public class HybridConnectionListener implements RelayTraceSource, AutoCloseable
 
 						if (json != null) {
 							RelayLogger.logEvent("sendCommand", this, json);
-							return webSocket.writeAsync(json, timeout, WriteMode.TEXT)
+							return webSocket.writeAsync(json, timeout, true, WriteMode.TEXT)
 								.thenCompose($void -> {
 									if (buffer != null) {
 										return webSocket.writeAsync(buffer);

--- a/src/main/java/com/microsoft/azure/relay/HybridConnectionListener.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridConnectionListener.java
@@ -436,7 +436,7 @@ public class HybridConnectionListener implements RelayTraceSource, AutoCloseable
 				} catch (Exception userException) {
                     listenerContext.getResponse().setStatusCode(HttpStatus.BAD_GATEWAY_502);
                     listenerContext.getResponse().setStatusDescription("The Listener's custom AcceptHandler threw an exception. See Listener logs for details. TrackingId: " + listenerContext.getTrackingContext().getTrackingId());
-					throw userException;
+					throw RelayLogger.throwingException(userException, this);
 				}
 			}
 

--- a/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
@@ -209,24 +209,27 @@ class HybridHttpConnection implements RelayTraceSource {
 			return this.listener.sendControlCommandAndStreamAsync(listenerCommand, responseBodyBuffer, timeout)
 					.thenRun(() -> RelayLogger.logEvent("httpSendResponseFinished", this, "control", String.valueOf(responseCommand.getStatusCode())));
 		} else {
+			TimeoutHelper timeRemaining = new TimeoutHelper(timeout);
 			RelayLogger.logEvent("httpSendResponse", this, "rendezvous", String.valueOf(responseCommand.getStatusCode()));
-			this.ensureRendezvousAsync(timeout).join();
 
 			ListenerCommand listenerCommand = new ListenerCommand(null);
 			listenerCommand.setResponse(responseCommand);
 			String command = listenerCommand.getResponse().toJsonString();
 
 			// We need to respond over the rendezvous connection
-			CompletableFuture<Void> sendCommandTask = this.rendezvousWebSocket.writeAsync(command, timeout, WriteMode.TEXT)
-					.thenAccept(bytesWritten -> {
-						RelayLogger.logEvent("httpSendResponseFinished", this, "rendezvous", String.valueOf(responseCommand.getStatusCode()));
-					});
+			CompletableFuture<Void> sendCommandTask = this.ensureRendezvousAsync(timeRemaining.remainingTime())
+				.thenCompose($void -> this.rendezvousWebSocket.writeAsync(command, timeRemaining.remainingTime(), true, WriteMode.TEXT))
+				.thenAccept(bytesWritten -> {
+					RelayLogger.logEvent("httpSendResponseFinished", this, "rendezvous", String.valueOf(responseCommand.getStatusCode()));
+				});
+			
 			if (responseCommand.hasBody() && responseBodyBuffer != null) {
 				return sendCommandTask.thenCompose($void -> {
 					int bytesToWrite = responseBodyBuffer.remaining();
-					return this.rendezvousWebSocket.writeAsync(responseBodyBuffer.array(), timeout).thenAccept(nullResult -> {
-						RelayLogger.logEvent("httpSendingBytes", this, String.valueOf(bytesToWrite));
-					});
+					return sendBytesOverRendezvousAsync(responseBodyBuffer, timeRemaining.remainingTime())
+						.thenRun(() -> {
+							RelayLogger.logEvent("httpSendingBytes", this, String.valueOf(bytesToWrite));
+						});
 				});
 			}
 			return sendCommandTask;
@@ -237,7 +240,7 @@ class HybridHttpConnection implements RelayTraceSource {
 		if (buffer == null) {
 			return CompletableFuture.completedFuture(null);
 		}
-		return this.rendezvousWebSocket.writeAsync(buffer, timeout).thenAccept(nullResult -> {
+		return this.rendezvousWebSocket.writeAsync(buffer, timeout, false, WriteMode.BINARY).thenAccept(nullResult -> {
 			RelayLogger.logEvent("httpSendingBytes", this, String.valueOf(buffer.remaining()));
 		});
 	}
@@ -324,13 +327,20 @@ class HybridHttpConnection implements RelayTraceSource {
 
 				// When there is no request message body
 				if (this.writeBufferStream != null && this.writeBufferStream.position() > 0) {
-					return CompletableFuture.allOf(sendResponseTask, this.connection
-							.sendBytesOverRendezvousAsync(this.writeBufferStream, timeout).thenRun(() -> {
-								this.writeBufferStream.clear();
-								if (this.writeBufferFlushTimer != null) {
-									this.writeBufferFlushTimer.cancel();
-								}
-							}));
+					return sendResponseTask.thenCompose($void -> {
+						// Get a new buffer backed by the non empty segment of the write buffer array
+						this.writeBufferStream.flip();
+						ByteBuffer trimmedBuffer = ByteBuffer.wrap(
+								this.writeBufferStream.array(), 
+								this.writeBufferStream.position(), 
+								this.writeBufferStream.remaining());
+						return this.connection.sendBytesOverRendezvousAsync(trimmedBuffer, timeout);
+					}).thenRun(() -> {
+						this.writeBufferStream.clear();
+						if (this.writeBufferFlushTimer != null) {
+							this.writeBufferFlushTimer.cancel();
+						}
+					});
 				}
 				return sendResponseTask;
 			}

--- a/src/main/java/com/microsoft/azure/relay/RelayLogger.java
+++ b/src/main/java/com/microsoft/azure/relay/RelayLogger.java
@@ -113,7 +113,6 @@ final class RelayLogger {
 		map.put("connecting", "%s is connecting.");
 		map.put("connected", "%s is connected.");
 		map.put("disconnect", "%s: is disconnected, should reconnect = %s");
-		map.put("doneWritingBytes", "%s: finished writing %s bytes to remote.");
 		map.put("getTokenStart", "%s: getToken start.");
 		map.put("getTokenStop", "%s: getToken stop. New token expires at %s.");
 		map.put("httpCreateRendezvous", "%s: Creating the rendezvous connection.");
@@ -127,7 +126,6 @@ final class RelayLogger {
 		map.put("httpSendingBytes", "%s: Sending %s bytes on the rendezvous connection");
 		map.put("httpSendResponse", "%s: Sending the response command on the %s connection, status: %s.");
 		map.put("httpSendResponseFinished", "%s: Finished sending the response command on the %s connection, status: %s.");
-		map.put("httpUserRequestHandlerException", "%s: exception in the user's request handler.");
 		map.put("httpWrittenToBuffer", "%s: finished writing %s bytes to ResponseStream buffer.");
 		map.put("objectNotSet", "%s: %s was not set to the given value.");
 		map.put("offline", "%s is offline.");
@@ -143,6 +141,7 @@ final class RelayLogger {
 		map.put("tokenRenewNegativeDuration", "%s: Not renewing token because the duration left on the token is negative.");
 		map.put("tokenRenewScheduled", "%s: Scheduling Token renewal after %s.");
 		map.put("writingBytes", "%s: starting to write to remote. Writemode: %s");
+		map.put("writingBytesFinished", "%s: finished writing %s bytes to remote.");
 		map.put("writingBytesFailed", "%s: writing bytes failed.");
 
 		Messages = Collections.unmodifiableMap(map);

--- a/src/main/java/com/microsoft/azure/relay/RelayLogger.java
+++ b/src/main/java/com/microsoft/azure/relay/RelayLogger.java
@@ -128,6 +128,7 @@ final class RelayLogger {
 		map.put("httpSendResponse", "%s: Sending the response command on the %s connection, status: %s.");
 		map.put("httpSendResponseFinished", "%s: Finished sending the response command on the %s connection, status: %s.");
 		map.put("httpUserRequestHandlerException", "%s: exception in the user's request handler.");
+		map.put("httpWrittenToBuffer", "%s: finished writing %s bytes to ResponseStream buffer.");
 		map.put("objectNotSet", "%s: %s was not set to the given value.");
 		map.put("offline", "%s is offline.");
 		map.put("parsingUUIDFailed", "%s: Parsing TrackingId '%s' as Guid failed, created new ActivityId '%s' for trace correlation.");

--- a/src/main/java/com/microsoft/azure/relay/WebSocketChannel.java
+++ b/src/main/java/com/microsoft/azure/relay/WebSocketChannel.java
@@ -120,7 +120,7 @@ public class WebSocketChannel implements HybridConnectionChannel {
 	 * @return A CompletableFuture which completes when websocket finishes sending the bytes.
 	 * @throws TimeoutException Throws when the sending task does not complete within the given timeout.
 	 */
-	CompletableFuture<Void> writeAsync(Object data, Duration timeout, WriteMode mode) {
-		return this.websocket.writeAsync(data, timeout, mode);
+	CompletableFuture<Void> writeAsync(Object data, Duration timeout, boolean isEnd, WriteMode mode) {
+		return this.websocket.writeAsync(data, timeout, isEnd, mode);
 	}
 }

--- a/src/test/java/com/microsoft/azure/relay/SendReceiveTest.java
+++ b/src/test/java/com/microsoft/azure/relay/SendReceiveTest.java
@@ -206,20 +206,26 @@ public class SendReceiveTest {
 	
 	@Test
 	public void httpWriteSmallThenSmallResponseTest() throws IOException {
-		listener.setRequestHandler(context -> httpRequestHandlerMultipleSend(context, smallStr, smallStr));
+		listener.setRequestHandler(context -> httpRequestHandlerMultipleSend(context, smallStr, smallStr, false));
 		httpRequestSender("POST", smallStr + smallStr, smallStr);
 	}
 	
 	@Test
 	public void httpWriteSmallThenLargeResponseTest() throws IOException {
-		listener.setRequestHandler(context -> httpRequestHandlerMultipleSend(context, smallStr, largeStr));
+		listener.setRequestHandler(context -> httpRequestHandlerMultipleSend(context, smallStr, largeStr, false));
 		httpRequestSender("POST", smallStr + largeStr, smallStr);
 	}
 	
 	@Test
 	public void httpWriteLargeThenSmallResponseTest() throws IOException {
-		listener.setRequestHandler(context -> httpRequestHandlerMultipleSend(context, largeStr, smallStr));
+		listener.setRequestHandler(context -> httpRequestHandlerMultipleSend(context, largeStr, smallStr, false));
 		httpRequestSender("POST", largeStr + smallStr, smallStr);
+	}
+	
+	@Test
+	public void httpWriteResponseAfterFlushTimerTest() throws IOException {
+		listener.setRequestHandler(context -> httpRequestHandlerMultipleSend(context, smallStr, smallStr, true));
+		httpRequestSender("POST", smallStr + smallStr, smallStr);
 	}
 	
 	private static CompletableFuture<Void> websocketClient(String msgExpected, String msgToSend) {
@@ -309,18 +315,24 @@ public class SendReceiveTest {
 			builder.append(inputLine);
 		}
 		inStream.close();
+		assertEquals("Http connection sender did not receive the expected response message size.", 
+				msgExpected.length(), 
+				builder.toString().length());
 		assertEquals("Http connection sender did not receive the expected response message.", msgExpected, builder.toString());
 	}
 	
-	private static void httpRequestHandlerMultipleSend(RelayedHttpListenerContext context, String firstMsg, String secondMsg) {
+	private static void httpRequestHandlerMultipleSend(RelayedHttpListenerContext context, String firstMsg, String secondMsg, boolean hasPause) {
 		RelayedHttpListenerResponse response = context.getResponse();
 		response.setStatusCode(STATUS_CODE);
 		response.setStatusDescription(STATUS_DESCRIPTION);
 		
 		try {
 			response.getOutputStream().write(firstMsg.getBytes());
+			if (hasPause) {
+				Thread.sleep(2500);
+			}
 			response.getOutputStream().write(secondMsg.getBytes());
-		} catch (IOException e) {
+		} catch (IOException | InterruptedException e) {
 			fail(e.getMessage());
 		} finally {
 		    context.getResponse().close();


### PR DESCRIPTION
- Added lock to ClientWebSocket to prevent exception from the websocket API when multiple sends are attempted simultaneously.

- Added trimming to HTTP response buffer to ensure that empty bytes do not get sent.

- Added tests to ensure consecutive writes to HTTP response is working properly.