### PR TITLE
Allow writeAsync() for users in HybridHttpConnection.ResponseStream

### DIFF
--- a/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.relay;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -279,7 +280,7 @@ class HybridHttpConnection implements RelayTraceSource {
 	}
 
 	final class ResponseStream extends OutputStream {
-		private static final long WRITE_BUFFER_FLUSH_TIMEOUT_MILLIS = 2000;
+		static final long WRITE_BUFFER_FLUSH_TIMEOUT_MILLIS = 2000;
 		private final HybridHttpConnection connection;
 		private final RelayedHttpListenerContext context;
 		private final AsyncLock asyncLock;
@@ -346,21 +347,58 @@ class HybridHttpConnection implements RelayTraceSource {
 			return CompletableFuture.completedFuture(null);
 		}
 
+		/**
+		 * Writes the specified byte to this response stream.
+		 */
 		@Override
-		public void write(int b) {
-			this.writeAsync(new byte[] { (byte) b }, 0, 1).join();
+		public void write(int b) throws IOException {
+			try {
+				this.writeAsync(new byte[] { (byte) b }, 0, 1).join();
+			} catch (CompletionException e) {
+				throw new IOException(e.getCause());
+			}
 		}
 
-		public void write(byte[] bytes) {
-			this.writeAsync(bytes, 0, bytes.length).join();
+		/**
+		 * Writes b.length bytes from the specified byte array to this response stream.
+		 */
+		@Override
+		public void write(byte[] b) throws IOException {
+			try {
+				this.writeAsync(b, 0, b.length).join();
+			} catch (CompletionException e) {
+				throw new IOException(e.getCause());
+			}
+		}
+		
+		/**
+		 * Writes len bytes from the specified byte array starting at offset off to this response stream.
+		 */
+		@Override
+		public void write(byte[] b, int off, int len) throws IOException {
+			try {
+				this.writeAsync(b, off, len).join();
+			} catch (CompletionException e) {
+				throw new IOException(e.getCause());
+			}
 		}
 
-		public void write(String text) {
-			this.writeAsync(text.getBytes(StringUtil.UTF8), 0, text.length()).join();
+		/**
+		 * Writes the given text to this response stream.
+		 */
+		public void write(String text) throws IOException {
+			try {
+				this.writeAsync(text.getBytes(StringUtil.UTF8), 0, text.length()).join();
+			} catch (CompletionException e) {
+				throw new IOException(e.getCause());
+			}
 		}
 
-		public CompletableFuture<Void> writeAsync(byte[] array, int offset, int count) {
-			RelayLogger.logEvent("httpResponseStreamWrite", this, String.valueOf(count));
+		/**
+		 * Writes len bytes from the specified byte array starting at offset off to this response stream concurrently.
+		 */
+		public CompletableFuture<Void> writeAsync(byte[] b, int off, int len) {
+			RelayLogger.logEvent("httpResponseStreamWrite", this, String.valueOf(len));
 			this.context.getResponse().setReadonly();
 			return this.asyncLock.acquireThenCompose(this.writeTimeout, () -> {
 				CompletableFuture<Void> flushCoreTask = null;
@@ -371,7 +409,7 @@ class HybridHttpConnection implements RelayTraceSource {
 						flushReason = FlushReason.RENDEZVOUS_EXISTS;
 					} else {
 						int bufferedCount = this.writeBufferStream != null ? this.writeBufferStream.position() : 0;
-						if (count + bufferedCount <= MAX_CONTROL_CONNECTION_BODY_SIZE) {
+						if (len + bufferedCount <= MAX_CONTROL_CONNECTION_BODY_SIZE) {
 
 							// There's still a chance we might be able to respond over the control
 							// connection, accumulate bytes
@@ -387,7 +425,7 @@ class HybridHttpConnection implements RelayTraceSource {
 								}, WRITE_BUFFER_FLUSH_TIMEOUT_MILLIS, Long.MAX_VALUE);
 
 							}
-							this.writeBufferStream.put(array, offset, count);
+							this.writeBufferStream.put(b, off, len);
 							return CompletableFuture.completedFuture(null);
 						}
 						flushReason = FlushReason.BUFFER_FULL;
@@ -398,7 +436,7 @@ class HybridHttpConnection implements RelayTraceSource {
 					flushCoreTask = this.flushCoreAsync(flushReason, this.writeTimeout);
 				}
 
-				ByteBuffer buffer = ByteBuffer.wrap(array, offset, count);
+				ByteBuffer buffer = ByteBuffer.wrap(b, off, len);
 				if (flushCoreTask == null) {
 					flushCoreTask = CompletableFuture.completedFuture(null);
 				}

--- a/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
@@ -383,13 +383,6 @@ class HybridHttpConnection implements RelayTraceSource {
 		}
 
 		/**
-		 * Writes the given text to this response stream.
-		 */
-		public void write(String text) throws IOException {
-			this.write(text.getBytes(StringUtil.UTF8), 0, text.length());
-		}
-
-		/**
 		 * Writes len bytes from the specified byte array starting at offset off to this response stream concurrently.
 		 */
 		public CompletableFuture<Void> writeAsync(byte[] b, int off, int len) {

--- a/src/main/java/com/microsoft/azure/relay/RelayedHttpListenerResponse.java
+++ b/src/main/java/com/microsoft/azure/relay/RelayedHttpListenerResponse.java
@@ -1,7 +1,6 @@
 package com.microsoft.azure.relay;
 
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -67,7 +66,7 @@ public class RelayedHttpListenerResponse {
 		return headers;
 	}
 
-	public OutputStream getOutputStream() {
+	public HybridHttpConnection.ResponseStream getOutputStream() {
 		return outputStream;
 	}
 

--- a/src/test/java/com/microsoft/azure/relay/SendReceiveTest.java
+++ b/src/test/java/com/microsoft/azure/relay/SendReceiveTest.java
@@ -310,17 +310,15 @@ public class SendReceiveTest {
 		response.setStatusCode(STATUS_CODE);
 		response.setStatusDescription(STATUS_DESCRIPTION);
 		
-		CompletableFuture<?>[] cfs = new CompletableFuture<?>[messages.length];
 		try {
 			for (int i = 0; i < messages.length; i++) {
-				cfs[i] = response.getOutputStream().writeAsync(messages[i].getBytes(), 0, messages[i].length());
+				response.getOutputStream().writeAsync(messages[i].getBytes(), 0, messages[i].length()).join();
 				
 				// Pause for testing the flush timeout
 				if (hasPause && i < messages.length - 1) {
 					Thread.sleep(ResponseStream.WRITE_BUFFER_FLUSH_TIMEOUT_MILLIS);
 				}
 			}
-			CompletableFuture.allOf(cfs).join();
 		} catch (Exception e) {
 			fail(e.getMessage());
 		} finally {


### PR DESCRIPTION
- Changed the type of output stream from HTTP context object to expose writeAsync()
- Slightly modified overrides of write methods from ResponseStream to resemble OutputStream signatures
- Refactored tests