### PR TITLE
make status description for HTTP response be JSON safe

### DIFF
--- a/src/main/java/com/microsoft/azure/relay/ListenerCommand.java
+++ b/src/main/java/com/microsoft/azure/relay/ListenerCommand.java
@@ -335,7 +335,10 @@ class ListenerCommand {
 			fields.add("\"statusCode\":" + this.statusCode);
 
 			if (this.statusDescription != null) {
-				fields.add("\"statusDescription\":\"" + this.statusDescription + "\"");
+			    Map<String, String> descriptionMap = new HashMap<String, String>();
+			    descriptionMap.put("statusDescription", this.statusDescription);
+			    String description = new JSONObject(descriptionMap).toString();
+			    fields.add(description.substring(1, description.length() - 1)); //.substring() to remove the {}
 			}
 
 			if (this.responseHeaders != null && !this.responseHeaders.isEmpty()) {

--- a/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
+++ b/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
@@ -123,12 +123,14 @@ public class HybridConnectionListenerTest {
 	    OutputStream out = httpConnection.getOutputStream();
 	    out.close();
 	    int responseCode = httpConnection.getResponseCode();
+	    String responseDescription = httpConnection.getResponseMessage();
 
 	    Map<String, List<String>> headers = httpConnection.getHeaderFields();
 	    assertNotNull(headers);
 	    assertEquals("The response did not contain the expected header",
 	            Arrays.asList(new String[] { allowedHeaderValChars }), headers.get(allowedHeaderNameChars));
 	    assertEquals(httpConnection.getResponseMessage(), 200, responseCode);
+	    assertEquals("Http connection sender did not receive the expected response description.", allowedHeaderValChars, responseDescription);
 	    httpRequestReceived.get(10, TimeUnit.SECONDS);
 
 	    // Test sending custom header from client and receiving from listener for

--- a/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
+++ b/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
@@ -87,6 +87,7 @@ public class HybridConnectionListenerTest {
 	        try {
 	            Map<String, String> headers = context.getRequest().getHeaders();
 	            assertEquals(allowedHeaderValChars, headers.get(allowedHeaderNameChars));
+	            context.getResponse().setStatusDescription(allowedHeaderValChars);
 	            context.getResponse().getHeaders().put(allowedHeaderNameChars, allowedHeaderValChars);
 	            httpRequestReceived.complete(null);
 	        } catch (Throwable ex) {


### PR DESCRIPTION
Make status description for HTTP response be JSON safe with same approach used on the custom response headers.