### PR TITLE
Hybrid HTTP connection handles URL requests with spaces. 

### DIFF
--- a/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
@@ -20,6 +20,7 @@ import javax.websocket.CloseReason;
 import javax.websocket.CloseReason.CloseCodes;
 
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.URIUtil;
 import org.json.JSONObject;
 
 class HybridHttpConnection implements RelayTraceSource {
@@ -164,11 +165,7 @@ class HybridHttpConnection implements RelayTraceSource {
 		URI requestUri = null;
 
 		try {
-			String listenerAddressStr = listenerAddress.toString();
-			requestTarget = requestTarget.replaceFirst(listenerAddress.getPath(), "");
-			requestUri = (listenerAddressStr.endsWith("/") || requestTarget.startsWith("/"))
-					? new URI(listenerAddressStr + requestTarget)
-					: new URI(listenerAddressStr + "/" + requestTarget);
+			requestUri = parseRequestUri(listenerAddress, requestTarget);
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}
@@ -206,6 +203,23 @@ class HybridHttpConnection implements RelayTraceSource {
             listenerContext.getResponse().setStatusDescription("The listener RequestHandler has not been configured.");
 			listenerContext.getResponse().close();
 		}
+	}
+
+	private URI parseRequestUri(URI listenerAddress, String requestTarget) throws URISyntaxException {
+		URI requestUri;
+		String listenerAddressStr = listenerAddress.toString();
+		String requestTargetWithoutConnectionName = requestTarget.replaceFirst(listenerAddress.getPath(), "");
+
+		if (requestTargetWithoutConnectionName.startsWith("/")){
+			requestTargetWithoutConnectionName = requestTargetWithoutConnectionName.replaceFirst("/","");
+		}
+
+		String[] pathAndQuery = requestTargetWithoutConnectionName.split("\\?",2);
+		pathAndQuery[0] = URIUtil.encodePath(pathAndQuery[0]);
+
+		requestUri = new URI(listenerAddressStr + "/" +
+				String.join("?",pathAndQuery));
+		return requestUri;
 	}
 
 	private CompletableFuture<Void> sendResponseAsync(ListenerCommand.ResponseCommand responseCommand,

--- a/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridHttpConnection.java
@@ -165,7 +165,7 @@ class HybridHttpConnection implements RelayTraceSource {
 		URI requestUri = null;
 
 		try {
-			requestUri = parseRequestUri(listenerAddress, requestTarget);
+			requestUri = parseAndEncodeRequestUri(listenerAddress, requestTarget);
 		} catch (URISyntaxException e) {
 			throw new RuntimeException(e);
 		}
@@ -205,7 +205,7 @@ class HybridHttpConnection implements RelayTraceSource {
 		}
 	}
 
-	private URI parseRequestUri(URI listenerAddress, String requestTarget) throws URISyntaxException {
+	static URI parseAndEncodeRequestUri(URI listenerAddress, String requestTarget) throws URISyntaxException {
 		URI requestUri;
 		String listenerAddressStr = listenerAddress.toString();
 		String requestTargetWithoutConnectionName = requestTarget.replaceFirst(listenerAddress.getPath(), "");

--- a/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
+++ b/src/test/java/com/microsoft/azure/relay/HybridConnectionListenerTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.websocket.api.StatusCode;
 import org.eclipse.jetty.websocket.api.UpgradeException;
 import org.junit.After;
@@ -315,7 +316,57 @@ public class HybridConnectionListenerTest {
 			fail(e.getMessage());
 		}
 	}
-	
+
+	@Test
+	public void parseRequestPathWithSpacesAndQueryTest() throws IOException {
+		CompletableFuture<Void> requestReceived = new CompletableFuture<Void>();
+		String extraPath = "/extra Path/extra  Path2";
+		String extraQuery = "queryKey=queryValue&queryKey2=queryValue;"; // mixing in a special char just for fun
+
+		listener.setRequestHandler((context) -> {
+			try {
+				assertNotNull("Listener should have received a valid http context.", context);
+				assertNotNull("Listener should have received a valid http request.", context.getRequest());
+
+				URI requestUri = context.getRequest().getUri();
+				assertNotNull("Listener should have a URI from request", requestUri);
+				assertEquals(
+						"The path wasn't the expected value",
+						"/" + TestUtil.ENTITY_PATH + extraPath,
+						requestUri.getPath()
+				);
+				assertEquals("The query wasn't the expected value", extraQuery, requestUri.getQuery());
+
+				requestReceived.complete(null);
+			} catch (Throwable ex) {
+				requestReceived.completeExceptionally(ex);
+			} finally {
+				context.getResponse().close();
+			}
+		});
+
+		listener.openAsync(Duration.ofSeconds(15)).join();
+		StringBuilder urlBuilder = new StringBuilder(TestUtil.RELAY_NAMESPACE_URI + TestUtil.ENTITY_PATH);
+		urlBuilder.replace(0, 5, "https://");
+		urlBuilder.append(URIUtil.encodePath(extraPath));
+		urlBuilder.append("?").append(extraQuery);
+
+		URL url = new URL(urlBuilder.toString());
+		String tokenString = tokenProvider.getTokenAsync(url.toString(), Duration.ofHours(1)).join().getToken();
+
+		HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+		conn.setRequestMethod("GET");
+		conn.setRequestProperty("ServiceBusAuthorization", tokenString);
+
+		conn.getResponseCode();
+		try {
+			assertNull(requestReceived.get(30, TimeUnit.SECONDS));
+		} catch (Exception e) {
+			fail(e.getMessage());
+		}
+	}
+
+
 	@Test
 	public void listenerReconnectionTest() {
 		AtomicInteger handlerExecuted = new AtomicInteger(0);


### PR DESCRIPTION
The path part of the request URI is encoded using jetty ```URIUtil.encodePath``` - which is already a dependency in the SDK. 

Closes #82 