### PR TITLE
Update GetAudience to Append Entity Path

### DIFF
--- a/src/main/java/com/microsoft/azure/relay/HybridConnectionUtil.java
+++ b/src/main/java/com/microsoft/azure/relay/HybridConnectionUtil.java
@@ -32,7 +32,7 @@ final class HybridConnectionUtil {
 		if (port > -1) {
 			audience.append(":").append(port);
 		}
-		if (StringUtil.isNullOrEmpty(path)) {
+		if (!StringUtil.isNullOrEmpty(path)) {
 			audience.append("/").append(path);
 		}
 		


### PR DESCRIPTION
HybridConnectionClient uses GetAudience when creating a token. Previously, path was not being added to audience so the token was valid on the namespace level. The bool check was updated to properly add path to audience. All tests passed locally.